### PR TITLE
Fixed bug where trace_id was always set to true.

### DIFF
--- a/lib/imprint/tracer.rb
+++ b/lib/imprint/tracer.rb
@@ -22,10 +22,10 @@ module Imprint
     end
 
     def self.insert_trace_id_in_message(message)
-      if message && message.is_a?(String) &&
-          message.length > 1 && !message.include?('trace_id=') &&
-          trace_id = get_trace_id && trace_id != TRACE_ID_DEFAULT
-        message.gsub!("\n"," trace_id=#{trace_id}\n")
+      if message && message.is_a?(String) && message.length > 1 && !message.include?('trace_id=')
+        trace_id = get_trace_id
+
+        message.gsub!("\n"," trace_id=#{trace_id}\n") if trace_id && trace_id != TRACE_ID_DEFAULT
       end
     end
 


### PR DESCRIPTION
When using the new imprint 1.4.0 version the trace_id was always set to true when using ruby v2.1.2. Didn't test with other versions. Broke apart the conditional where the trace_id was being set so it is not set in the conditional. Verified the trace_id was set to IMPRINTID header after the fix was applied.
