### PR TITLE
Keep the default tracer id as a string

### DIFF
--- a/lib/imprint/tracer.rb
+++ b/lib/imprint/tracer.rb
@@ -3,7 +3,7 @@ module Imprint
     TRACER_HEADER    = 'HTTP_IMPRINTID'
     TRACER_KEY       = 'IMPRINTID'
     RAILS_REQUEST_ID = "action_dispatch.request_id"
-    TRACE_ID_DEFAULT = -1
+    TRACE_ID_DEFAULT = "-1"
 
     TRACE_CHARS = [('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
 


### PR DESCRIPTION
Net/HTTP requires that headers be strings. This works fine normally, since imprint makes strings for the trace_id. However, when running request specs, the trace id is still the default in test/dev environments.