### PR TITLE
timestamp support added to start of every line

### DIFF
--- a/imprint.gemspec
+++ b/imprint.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "shoulda"
   spec.add_development_dependency "rack"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "timecop"
 end

--- a/lib/imprint/version.rb
+++ b/lib/imprint/version.rb
@@ -1,3 +1,3 @@
 module Imprint
-  VERSION = "1.4.2"
+  VERSION = "1.4.3.pre"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'simplecov'
 require 'minitest/autorun'
 require 'shoulda'
 require 'rack'
+require 'timecop'
 
 SimpleCov.start do
   add_filter 'specs/ruby/1.9.1/gems/'

--- a/test/unit/tracer_test.rb
+++ b/test/unit/tracer_test.rb
@@ -8,6 +8,17 @@ class TracerTest < Minitest::Test
     assert_equal fake_trace, Imprint::Tracer.get_trace_id
   end
 
+  should "set trace timestamp" do
+    fake_trace = "tracer"
+    Timecop.freeze do
+      test_time = Time.now
+      Imprint::Tracer.set_trace_id(fake_trace, fake_rack_env)
+      # timecop has a bug with millisec time on osx
+      # this makes the check ignore millisec
+      assert !!Imprint::Tracer.get_trace_timestamp.to_s.match(/#{test_time.to_i.to_s}/)
+    end
+  end
+
   should "get trace id defaults" do
     assert_equal Imprint::Tracer::TRACE_ID_DEFAULT, Imprint::Tracer.get_trace_id
     Imprint::Tracer.set_trace_id("fake_trace", fake_rack_env)
@@ -16,6 +27,15 @@ class TracerTest < Minitest::Test
     assert_equal Imprint::Tracer::TRACE_ID_DEFAULT, Imprint::Tracer.get_trace_id
   end
 
+  should "get trace timestamp defaults" do
+    Timecop.freeze do
+      test_time = Time.now
+      # timecop has a bug with millisec time on osx
+      # this makes the check ignore millisec
+      assert !!Imprint::Tracer.get_trace_timestamp.to_s.match(/#{test_time.to_i.to_s}/)
+    end
+  end
+  
   should "generate rand trace id" do
     trace_id = Imprint::Tracer.rand_trace_id
     refute_nil trace_id


### PR DESCRIPTION
this should help with some events not getting correctly merged in Splunk. Because the docs aren't entirely clear on the best time format especially to support millisec time, this is a pre release we can test before making an official release. In the official release I will also likely add making the timestamp optional.